### PR TITLE
Making pip to install a certain version of cohere package(4.51)

### DIFF
--- a/Day2/commercial_llm_apis.ipynb
+++ b/Day2/commercial_llm_apis.ipynb
@@ -1,21 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "CehDPwHkOmTM"
+      },
       "source": [
         "# Leveraging comercially available LLM APIs.\n",
         "\n",
@@ -35,25 +24,22 @@
         "\n",
         "---\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "CehDPwHkOmTM"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "id": "_H2Whdrtlndl",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "_H2Whdrtlndl",
         "outputId": "3ce29d06-3257-47e9-ede9-0fe4c0b266fa"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting cohere\n",
             "  Downloading cohere-4.51-py3-none-any.whl (52 kB)\n",
@@ -88,23 +74,19 @@
         }
       ],
       "source": [
-        "!pip install cohere"
+        "!pip install cohere==4.51"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from getpass import getpass\n",
-        "api_key = getpass('Enter the secret value: ')"
-      ],
+      "execution_count": 2,
       "metadata": {
-        "id": "hgbiRX_IoPnz",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "hgbiRX_IoPnz",
         "outputId": "814a44ae-6971-4091-ee8c-429f459c7c47"
       },
-      "execution_count": 2,
       "outputs": [
         {
           "name": "stdout",
@@ -113,10 +95,17 @@
             "Enter the secret value: ··········\n"
           ]
         }
+      ],
+      "source": [
+        "from getpass import getpass\n",
+        "api_key = getpass('Enter the secret value: ')"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ddnw4Xe_mOVv"
+      },
       "source": [
         "## Intent Classification\n",
         "\n",
@@ -126,13 +115,27 @@
         "- https://api.cohere.ai/v1/classify uses a few examples to create a classifier from a generative model .In the background, it constructs a few-shot classification prompt and uses it classify the input texts you pass to it.\n",
         "\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "ddnw4Xe_mOVv"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "zz75UdkymCWm",
+        "outputId": "b19fafcb-c37c-4a1e-ebef-39f39a9a5433"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[Classification<prediction: \"Start return or exchange\", confidence: 0.9933396, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.0027134062), 'Start return or exchange': LabelPrediction(confidence=0.9933396), 'Track order': LabelPrediction(confidence=0.003947017)}>, Classification<prediction: \"Track order\", confidence: 0.9955387, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.0040009124), 'Start return or exchange': LabelPrediction(confidence=0.00046039946), 'Track order': LabelPrediction(confidence=0.9955387)}>, Classification<prediction: \"Shipping and handling policy\", confidence: 0.999675, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.999675), 'Start return or exchange': LabelPrediction(confidence=0.00027763066), 'Track order': LabelPrediction(confidence=4.7405712e-05)}>]\n"
+          ]
+        }
+      ],
       "source": [
         "import cohere\n",
         "from cohere.responses.classify import Example\n",
@@ -173,38 +176,38 @@
         "  examples=examples,\n",
         ")\n",
         "print(response)"
-      ],
-      "metadata": {
-        "id": "zz75UdkymCWm",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "b19fafcb-c37c-4a1e-ebef-39f39a9a5433"
-      },
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[Classification<prediction: \"Start return or exchange\", confidence: 0.9933396, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.0027134062), 'Start return or exchange': LabelPrediction(confidence=0.9933396), 'Track order': LabelPrediction(confidence=0.003947017)}>, Classification<prediction: \"Track order\", confidence: 0.9955387, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.0040009124), 'Start return or exchange': LabelPrediction(confidence=0.00046039946), 'Track order': LabelPrediction(confidence=0.9955387)}>, Classification<prediction: \"Shipping and handling policy\", confidence: 0.999675, labels: {'Shipping and handling policy': LabelPrediction(confidence=0.999675), 'Start return or exchange': LabelPrediction(confidence=0.00027763066), 'Track order': LabelPrediction(confidence=4.7405712e-05)}>]\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "af63GKFmPyEv"
+      },
       "source": [
         "## Summarization\n",
         "\n",
         "[Summarize API Doc](https://docs.cohere.com/reference/summarize-2)"
-      ],
-      "metadata": {
-        "id": "af63GKFmPyEv"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "US1sAXaEnXRX",
+        "outputId": "5752c75d-ca89-43ab-fa9c-656e802956ee"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Summary: The National Weather Service has issued a freeze warning for the Bay Area because temperatures are expected to fall into the mid-20s and low 30s. People in the area have been advised to take action in anticipation of the hard freeze.\n"
+          ]
+        }
+      ],
       "source": [
         "import cohere\n",
         "co = cohere.Client(api_key) # This is your trial API key\n",
@@ -238,38 +241,44 @@
         ")\n",
         "\n",
         "print('Summary:', response.summary)"
-      ],
-      "metadata": {
-        "id": "US1sAXaEnXRX",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "5752c75d-ca89-43ab-fa9c-656e802956ee"
-      },
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Summary: The National Weather Service has issued a freeze warning for the Bay Area because temperatures are expected to fall into the mid-20s and low 30s. People in the area have been advised to take action in anticipation of the hard freeze.\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "DTefh3lURRZP"
+      },
       "source": [
         "## Simple Generation\n",
         "\n",
         "[Generate API Doc](https://docs.cohere.com/reference/generate)"
-      ],
-      "metadata": {
-        "id": "DTefh3lURRZP"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eA_IVPQ1ujvq",
+        "outputId": "c93c911f-4fbb-4ded-8b59-2feb03cb2bde"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Prediction:  It was a fulfilling experience to conduct a day-long workshop on Large Langauge Models at the prestigious engineering college, XYZ. The students' enthusiasm and curiosity about this cutting-edge technology in AI were commendable. They actively participated in hands-on exercises and practical sessions, where they trained models and understood the intricacies of responsible AI development. \n",
+            "\n",
+            "The entire event was a success, thanks to the college's support and coordination. They ensured seamless logistics and provided us with a well-equipped venue and technical support, creating an ideal environment for knowledge-sharing and brainstorming. \n",
+            "\n",
+            "We are grateful for the opportunity to share our expertise in LLMs and look forward to conducting more such interactive sessions to empower students with the latest technological advancements. \n",
+            "\n",
+            "#ArtificialIntelligence #LargeLangaugeModels #Education #Collaboration #FulfillingExperience \n"
+          ]
+        }
+      ],
       "source": [
         "import cohere\n",
         "co = cohere.Client('4sa6zTNVa8RZGdWzBdhUWexlk74CzRAJjHDO4rAK') # This is your trial API key\n",
@@ -283,30 +292,21 @@
         "  stop_sequences=[],\n",
         "  return_likelihoods='NONE')\n",
         "print('Prediction: {}'.format(response.generations[0].text))"
-      ],
-      "metadata": {
-        "id": "eA_IVPQ1ujvq",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c93c911f-4fbb-4ded-8b59-2feb03cb2bde"
-      },
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Prediction:  It was a fulfilling experience to conduct a day-long workshop on Large Langauge Models at the prestigious engineering college, XYZ. The students' enthusiasm and curiosity about this cutting-edge technology in AI were commendable. They actively participated in hands-on exercises and practical sessions, where they trained models and understood the intricacies of responsible AI development. \n",
-            "\n",
-            "The entire event was a success, thanks to the college's support and coordination. They ensured seamless logistics and provided us with a well-equipped venue and technical support, creating an ideal environment for knowledge-sharing and brainstorming. \n",
-            "\n",
-            "We are grateful for the opportunity to share our expertise in LLMs and look forward to conducting more such interactive sessions to empower students with the latest technological advancements. \n",
-            "\n",
-            "#ArtificialIntelligence #LargeLangaugeModels #Education #Collaboration #FulfillingExperience \n"
-          ]
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
when we run `pip install cohere`, it will install the latest package(5.2.2 as of 6/4/'24), but there are some syntax changes in newer version, specifically in the `precog-iiith/LLMWorkshop/Day2/commercial_llm_apis.ipynb`  that is `from cohere.responses.classify import Example`
